### PR TITLE
WIP: Add bind_parameter_array for statements

### DIFF
--- a/examples/bind_columns.rs
+++ b/examples/bind_columns.rs
@@ -114,8 +114,8 @@ where
     C: CursorState,
 {
     use ReturnOption::*;
-    let cursor = cursor.bind_col(1, year, ind_year).into_result()?;
-    let cursor = cursor.bind_col(2, &mut title[..], ind_title).into_result()?;
+    let cursor = cursor.bind_col(1, year, Some(ind_year)).into_result()?;
+    let cursor = cursor.bind_col(2, &mut title[..], Some(ind_title)).into_result()?;
     let cursor = match cursor.fetch() {
         Success(s) | Info(s) => Some(s.reset_columns()),
         NoData(_) => None,

--- a/examples/prepared_query.rs
+++ b/examples/prepared_query.rs
@@ -34,7 +34,7 @@ fn execute_query<'a>(
     stmt: Statement<'a, 'a, 'a, NoCursor, Prepared>,
     year: i32,
 ) -> ResultSet<'a, 'a, 'a, Prepared> {
-    let stmt = stmt.bind_input_parameter(1, DataType::Integer, Some(&year))
+    let stmt = stmt.bind_input_parameter(1, DataType::Integer, &year, None)
         .unwrap();
     let stmt = match stmt.execute() {
         ReturnOption::Success(s) |

--- a/src/handles/hstmt.rs
+++ b/src/handles/hstmt.rs
@@ -136,6 +136,31 @@ impl<'env, 'param> HStmt<'env> {
         ).into()
     }
 
+    pub unsafe fn bind_parameter_set(
+        &mut self,
+        parameter_size: usize,
+        array_size: usize
+    ) -> Return<()>
+    {
+        let res: Return<()> = SQLSetStmtAttr(
+            self.handle,
+            SQL_ATTR_PARAM_BIND_TYPE,
+            parameter_size as SQLPOINTER,
+            0
+        ).into();
+
+        if res.is_err() {
+            return res;
+        }
+
+        SQLSetStmtAttr(
+            self.handle,
+            SQL_ATTR_PARAMSET_SIZE,
+            array_size as SQLPOINTER,
+            0
+        ).into()
+    }
+
     pub fn prepare<T>(&mut self, statement_text: &T) -> Return<()>
     where
         T: SqlStr + ?Sized,

--- a/src/return_.rs
+++ b/src/return_.rs
@@ -61,6 +61,15 @@ impl<T, E> Return<T, E> {
             Error(e) => Err(e.into()),
         }
     }
+
+    /// Indicates if this is `Error(e)` or `Success(v) | Info(v)`.
+    pub fn is_err( &self ) -> bool
+    {
+        match self {
+            &Success(_) | &Info(_) => false,
+            &Error(_) => true,
+        }
+    }
 }
 
 impl From<SQLRETURN> for Return<()> {

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -114,6 +114,24 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
         }
     }
 
+    pub unsafe fn bind_parameter_set<'p, T>(
+        mut self,
+        parameter_set: &'p [T]
+    ) -> Return<Statement<'con, 'p, 'col, S, A>, Self>
+    where
+        T: Sized,
+        'param: 'p,
+    {
+        match self.handle.bind_parameter_set(
+            std::mem::size_of::<T>(),
+            parameter_set.len(),
+        ) {
+            Success(()) => Success(self.transit()),
+            Info(()) => Info(self.transit()),
+            Error(()) => Error(self.transit()),
+        }
+    }
+
     /// Binds a buffer and an indicator to a column.
     ///
     /// See [SQLBindCol][1]:

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -93,7 +93,8 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
         mut self,
         parameter_number: SQLUSMALLINT,
         parameter_type: DataType,
-        value: Option<&'p T>,
+        value: &'p T,
+        indicator: Option<&'p SQLLEN>,
     ) -> Return<Statement<'con, 'p, 'col, S, A>, Self>
     where
         T: CDataType + ?Sized,
@@ -104,6 +105,7 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
                 parameter_number,
                 parameter_type,
                 value,
+                indicator,
             ) {
                 Success(()) => Success(self.transit()),
                 Info(()) => Info(self.transit()),
@@ -120,7 +122,7 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
         mut self,
         column_number: SQLUSMALLINT,
         value: &'col_new mut T,
-        indicator: &'col_new mut SQLLEN,
+        indicator: Option<&'col_new mut SQLLEN>,
     ) -> Return<Statement<'con, 'param, 'col_new, S, A>, Self>
     where
         T: CDataType + ?Sized,
@@ -372,7 +374,7 @@ impl<'con, 'param, 'col, A> Statement<'con, 'param, 'col, Positioned, A> {
     }
 }
 
-impl<'con, 'param, 'col, C> Diagnostics for Statement<'con, 'param, 'col, C> {
+impl<'con, 'param, 'col, C, A> Diagnostics for Statement<'con, 'param, 'col, C, A> {
     fn diagnostics(
         &self,
         rec_number: SQLSMALLINT,


### PR DESCRIPTION
This is aimed at support bulk insertions by binding vectors of parameters which can then be inserted using a single statement execution.

Note that this change includes the changes of #3