### PR TITLE
Expose indicators but make them optional

### DIFF
--- a/examples/bind_columns.rs
+++ b/examples/bind_columns.rs
@@ -114,8 +114,8 @@ where
     C: CursorState,
 {
     use ReturnOption::*;
-    let cursor = cursor.bind_col(1, year, ind_year).into_result()?;
-    let cursor = cursor.bind_col(2, &mut title[..], ind_title).into_result()?;
+    let cursor = cursor.bind_col(1, year, Some(ind_year)).into_result()?;
+    let cursor = cursor.bind_col(2, &mut title[..], Some(ind_title)).into_result()?;
     let cursor = match cursor.fetch() {
         Success(s) | Info(s) => Some(s.reset_columns()),
         NoData(_) => None,

--- a/examples/prepared_query.rs
+++ b/examples/prepared_query.rs
@@ -34,7 +34,7 @@ fn execute_query<'a>(
     stmt: Statement<'a, 'a, 'a, NoCursor, Prepared>,
     year: i32,
 ) -> ResultSet<'a, 'a, 'a, Prepared> {
-    let stmt = stmt.bind_input_parameter(1, DataType::Integer, Some(&year))
+    let stmt = stmt.bind_input_parameter(1, DataType::Integer, &year, None)
         .unwrap();
     let stmt = match stmt.execute() {
         ReturnOption::Success(s) |

--- a/src/handles/hstmt.rs
+++ b/src/handles/hstmt.rs
@@ -119,7 +119,10 @@ impl<'env, 'param> HStmt<'env> {
         T: CDataType + ?Sized,
     {
         let indicator: *const SQLLEN = match indicator {
-            Some(indicator) => indicator,
+            Some(indicator) => {
+                assert!(*indicator <= value.buffer_len(), "Indicator cannot be larger than buffer length.");
+                indicator
+            }
             None => null(),
         };
         SQLBindParameter(

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -93,7 +93,8 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
         mut self,
         parameter_number: SQLUSMALLINT,
         parameter_type: DataType,
-        value: Option<&'p T>,
+        value: &'p T,
+        indicator: Option<&'p SQLLEN>,
     ) -> Return<Statement<'con, 'p, 'col, S, A>, Self>
     where
         T: CDataType + ?Sized,
@@ -104,6 +105,7 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
                 parameter_number,
                 parameter_type,
                 value,
+                indicator,
             ) {
                 Success(()) => Success(self.transit()),
                 Info(()) => Info(self.transit()),
@@ -120,7 +122,7 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
         mut self,
         column_number: SQLUSMALLINT,
         value: &'col_new mut T,
-        indicator: &'col_new mut SQLLEN,
+        indicator: Option<&'col_new mut SQLLEN>,
     ) -> Return<Statement<'con, 'param, 'col_new, S, A>, Self>
     where
         T: CDataType + ?Sized,
@@ -372,7 +374,7 @@ impl<'con, 'param, 'col, A> Statement<'con, 'param, 'col, Positioned, A> {
     }
 }
 
-impl<'con, 'param, 'col, C> Diagnostics for Statement<'con, 'param, 'col, C> {
+impl<'con, 'param, 'col, C, A> Diagnostics for Statement<'con, 'param, 'col, C, A> {
     fn diagnostics(
         &self,
         rec_number: SQLSMALLINT,


### PR DESCRIPTION
Since #2 is getting a bit convoluted and the indicator issues is completely unrelated to the question of parameter resp. row sets, this change breaks out the indicator fixes as we cannot just synthesize them on the stack as their lifetime must be bound to the parameter resp. column it is indicating for.