### PR TITLE
RFC: Bind RefCell instances instead of bare references

### DIFF
--- a/examples/bind_columns.rs
+++ b/examples/bind_columns.rs
@@ -114,8 +114,8 @@ where
     C: CursorState,
 {
     use ReturnOption::*;
-    let cursor = cursor.bind_col(1, year, ind_year).into_result()?;
-    let cursor = cursor.bind_col(2, &mut title[..], ind_title).into_result()?;
+    let cursor = cursor.bind_col(1, year, Some(ind_year)).into_result()?;
+    let cursor = cursor.bind_col(2, &mut title[..], Some(ind_title)).into_result()?;
     let cursor = match cursor.fetch() {
         Success(s) | Info(s) => Some(s.reset_columns()),
         NoData(_) => None,

--- a/examples/prepared_query.rs
+++ b/examples/prepared_query.rs
@@ -34,7 +34,7 @@ fn execute_query<'a>(
     stmt: Statement<'a, 'a, 'a, NoCursor, Prepared>,
     year: i32,
 ) -> ResultSet<'a, 'a, 'a, Prepared> {
-    let stmt = stmt.bind_input_parameter(1, DataType::Integer, Some(&year))
+    let stmt = stmt.bind_input_parameter(1, DataType::Integer, &year, None)
         .unwrap();
     let stmt = match stmt.execute() {
         ReturnOption::Success(s) |

--- a/examples/print_table.rs
+++ b/examples/print_table.rs
@@ -68,7 +68,7 @@ where
     conn.connect("TestDataSource", "", "").into_result()
 }
 
-fn execute_query<'a>(conn: &'a Connection) -> MyResult<ResultSet<'a, 'a, 'a, Unprepared>> {
+fn execute_query<'a>(conn: &'a Connection) -> MyResult<ResultSet<'a, (), (), Unprepared>> {
     let stmt = Statement::with_parent(conn).unwrap();
     match stmt.exec_direct("SELECT * FROM MOVIES") {
         ReturnOption::Success(s) |
@@ -80,7 +80,7 @@ fn execute_query<'a>(conn: &'a Connection) -> MyResult<ResultSet<'a, 'a, 'a, Unp
     }
 }
 
-fn print_fields(result_set: ResultSet<Unprepared>) -> MyResult<()> {
+fn print_fields(result_set: ResultSet<(), (), Unprepared>) -> MyResult<()> {
     let cols = result_set.num_result_cols().unwrap();
     let mut buffer = [0u8; 512];
     let mut cursor = match result_set.fetch() {

--- a/src/c_data_type.rs
+++ b/src/c_data_type.rs
@@ -43,6 +43,25 @@ unsafe impl CDataType for [SQLCHAR] {
     }
 }
 
+// HACK: TODO: Rust does not seem to support generics over the array size, c.f. RFC 2000 and tracking issue #44580. How to handle a RefCell<[T; N]> then? Require usage of generic_array?
+unsafe impl CDataType for [SQLCHAR; 512] {
+    fn c_data_type() -> SqlCDataType {
+        SQL_C_BINARY
+    }
+
+    fn sql_ptr(&self) -> *const c_void {
+        self.as_ptr() as SQLPOINTER
+    }
+
+    fn mut_sql_ptr(&mut self) -> SQLPOINTER {
+        self.as_mut_ptr() as SQLPOINTER
+    }
+
+    fn buffer_len(&self) -> SQLLEN {
+        self.buf_len()
+    }
+}
+
 unsafe impl CDataType for SQLSMALLINT {
     fn c_data_type() -> SqlCDataType {
         SQL_C_SSHORT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,4 +50,4 @@ mod output_buffer;
 /// `Connection` can be used as a shorthand for a `DataSource` in `Connected` state.
 pub type Connection<'env> = DataSource<'env, Connected<'env>>;
 /// Shorthand for `Statements` in `Open` state.
-pub type ResultSet<'con, 'param, 'col, P> = Statement<'con, 'param, 'col, Open, P>;
+pub type ResultSet<'conn, Params, Cols, P> = Statement<'conn, Params, Cols, Open, P>;

--- a/src/statement.rs
+++ b/src/statement.rs
@@ -93,7 +93,8 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
         mut self,
         parameter_number: SQLUSMALLINT,
         parameter_type: DataType,
-        value: Option<&'p T>,
+        value: &'p T,
+        indicator: Option<&'p SQLLEN>,
     ) -> Return<Statement<'con, 'p, 'col, S, A>, Self>
     where
         T: CDataType + ?Sized,
@@ -104,6 +105,7 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
                 parameter_number,
                 parameter_type,
                 value,
+                indicator,
             ) {
                 Success(()) => Success(self.transit()),
                 Info(()) => Info(self.transit()),
@@ -120,7 +122,7 @@ impl<'con, 'param, 'col, S, A> Statement<'con, 'param, 'col, S, A> {
         mut self,
         column_number: SQLUSMALLINT,
         value: &'col_new mut T,
-        indicator: &'col_new mut SQLLEN,
+        indicator: Option<&'col_new mut SQLLEN>,
     ) -> Return<Statement<'con, 'param, 'col_new, S, A>, Self>
     where
         T: CDataType + ?Sized,
@@ -372,7 +374,7 @@ impl<'con, 'param, 'col, A> Statement<'con, 'param, 'col, Positioned, A> {
     }
 }
 
-impl<'con, 'param, 'col, C> Diagnostics for Statement<'con, 'param, 'col, C> {
+impl<'con, 'param, 'col, C, A> Diagnostics for Statement<'con, 'param, 'col, C, A> {
     fn diagnostics(
         &self,
         rec_number: SQLSMALLINT,


### PR DESCRIPTION
Since binding parameters and columns basically means sharing variables with the ODBC driver in a push/pull model, this change tries to make that sharing explicit via the usage of `RefCell` so that bindings can be reused, e.g. I can repeatedly execute an `INSERT` statement that was prepared and bound once after just modifying the content of those `RefCell` instances.

Of course, this is not really a zero overhead abstraction, but it almost certainly is less overhead the repeatedly destroying and recreating the bindings. If necessary, one could of course keep both mechanisms, i.e. just tracking the lifetimes as it is now with the additional type parameters `Params` and `Cols` to track bound `RefCell` instances. (The type signatures will of course not get prettier due to this.)

One completely open issue is that Rust does not yet support generics over integral constants so that `RefCell<[T; N]>` cannot really be handled AFAIK, but its erasure as `RefCell<[T]>` is not well formed as the type parameter becomes unsized. (I could provide a macro that generates a `CDataType` implementation for `[SQLCHAR; $N]` given any `$N`, but that is not a very ergonomic API.)

Having these bindings present would also allow us to check parameter and row set bindings by directly comparing address ranges, hence making it possible to expose them via a safe API.

Note that this includes the changes of #3