### PR TITLE
More type safety for Environment<V> struct

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -1,6 +1,7 @@
 use super::*;
 use sys::*;
 use std::marker::PhantomData;
+use version::VersionOption;
 
 /// An `Environment` is a global context, in which to access data.
 ///
@@ -14,21 +15,21 @@ use std::marker::PhantomData;
 /// See: [Environment Handles in the ODBC Reference][1]
 /// [1]: https://docs.microsoft.com/sql/odbc/reference/develop-app/environment-handles
 #[derive(Debug)]
-pub struct Environment<V> {
+pub struct Environment<V: VersionOption> {
     version: PhantomData<V>,
     /// Invariant: Should always point to a valid ODBC Environment with Version declared as V or
     /// `NoVersion`
     handle: HEnv,
 }
 
-impl<V> Environment<V> {
+impl<V: VersionOption> Environment<V> {
     /// Provides access to the raw ODBC environment handle.
     pub fn as_raw(&self) -> SQLHENV {
         self.handle.as_raw()
     }
 
     /// Express state transiton
-    fn transit<Other>(self) -> Environment<Other> {
+    fn transit<Other: VersionOption>(self) -> Environment<Other> {
         Environment {
             version: PhantomData,
             handle: self.handle,
@@ -138,7 +139,7 @@ impl Environment<NoVersion> {
     }
 }
 
-impl<V> Diagnostics for Environment<V> {
+impl<V: VersionOption> Diagnostics for Environment<V> {
     fn diagnostics(
         &self,
         rec_number: SQLSMALLINT,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,7 +1,9 @@
 use sys::*;
 
+pub trait VersionOption {}
+
 /// Type indicates an ODBC Version
-pub unsafe trait Version {
+pub unsafe trait Version: VersionOption {
     /// The `SQL_ATTR_ODBC_VERSION` used with `SQLSetEnvAttr`
     fn constant() -> OdbcVersion;
 }
@@ -10,6 +12,8 @@ pub unsafe trait Version {
 #[derive(Debug, Clone, Copy)]
 pub struct NoVersion;
 
+impl VersionOption for NoVersion {}
+
 /// Used to declare ODBC 3 specifications.
 #[derive(Debug, Clone, Copy)]
 pub struct Odbc3;
@@ -17,6 +21,8 @@ pub struct Odbc3;
 /// Used to declare ODBC 3.8 specifications.
 #[derive(Debug, Clone, Copy)]
 pub struct Odbc3m8;
+
+impl<V: Version> VersionOption for V {}
 
 unsafe impl Version for Odbc3 {
     fn constant() -> OdbcVersion {


### PR DESCRIPTION
I noticed that `struct Environment<V>` was previously unbounded and it was possible to create an instance of the struct(although one would have to go through some trouble to do so) with any type as `version` because it is of the `PhantomData` type.

idk if this change is preferable or it just adds to the noise even though the library is a bit more type safe with this change